### PR TITLE
Add Causeway demo

### DIFF
--- a/causeway/.gitignore
+++ b/causeway/.gitignore
@@ -1,0 +1,3 @@
+__pycache*
+*.sqlite3
+settings.py

--- a/causeway/README.md
+++ b/causeway/README.md
@@ -1,0 +1,84 @@
+# causeway
+ 
+A storage service geared toward small files with ECDSA signature auth that works with the 21 Bitcoin Computer
+
+This project is for a server that will store and return data for a certain amount of time and accept updates if they are signed by a user's payment address.
+
+***
+** Roadmap **
+
+* All storage expires after one year. Extended by uploading the same data. 
+* Data is kept if bandwidth is exceeded just no longer served until balance is increased.
+
+## REST API
+
+* All requests via HTTP GET except where noted.
+* Data returned as JSON.
+
+### /status
+    Parameters
+        None
+
+    Returns
+        uptime - time in seconds that the service has been running
+        stored - bytes stored
+        free - bytes free
+        price - satoshis for 1 MB storage + 50 MB transfer
+
+### /price
+    Parameters
+        None
+        
+    Returns
+        price - satoshis for 1 MB storage + 50 MB transfer
+    
+### /address
+    Parameters
+        contact - email or Bitmessage address to contact on expiration
+        address - account this will be used to fund
+        signature - signature for concatenation of contact and address by
+            private key for address
+        
+    Returns
+        address - a new, unused Bitcoin address
+
+### /nonce
+    Parameters
+        address - account requesting a nonce
+        
+    Returns
+        nonce - random 32-byte string
+        
+Note: nonce is stored until used or next nonce generated for address
+
+### /balance
+    Parameters
+        address - account on which to report balance
+        nonce - latest unused 32-byte string retrieved via /nonce
+        signature - signature over concat(address and last nonce received via /nonce call)
+        
+    Returns
+        balance - satoshis worth of value left on account
+
+### /get
+    Parameters
+        key - used to retrieve value
+        
+    Returns
+        key - the key that was requested
+        value - the last value stored for the key
+        
+Note: Charges bandwidth against key/value submitter's account.
+        
+### /put (POST)
+    Parameters
+        key - string
+        value - string
+        address - account to charge for this data
+        nonce - latest unused 32-byte string retrieved via /nonce
+        signature - signature over concat(key + value + address + nonce) by 
+            private key for address
+
+    Returns
+        status - "success" or "error: " + error reason
+            Possible error reasons

--- a/causeway/README.md
+++ b/causeway/README.md
@@ -4,16 +4,17 @@ A storage service geared toward small files with ECDSA signature auth that works
 
 This project is for a server that will store and return data for a certain amount of time and accept updates if they are signed by a user's payment address.
 
-***
-** Roadmap **
-
-* All storage expires after one year. Extended by uploading the same data. 
-* Data is kept if bandwidth is exceeded just no longer served until balance is increased.
-
 ## REST API
 
 * All requests via HTTP GET except where noted.
-* Data returned as JSON.
+* Data returned as JSON, formatted with indent=4 for now.
+
+### /help
+    Parameters
+        None
+
+    Returns
+        List of available endpoints
 
 ### /status
     Parameters
@@ -31,6 +32,21 @@ This project is for a server that will store and return data for a certain amoun
         
     Returns
         price - satoshis for 1 MB storage + 50 MB transfer
+
+### /nonce
+    Parameters
+        address - account requesting a nonce
+        
+    Returns
+        nonce - random 32-byte string
+        
+Note: nonce will later be stored until used or next nonce generated for address
+
+***
+** Roadmap **
+
+* All storage expires after one year. Extended by uploading the same data. 
+* Data is kept if bandwidth is exceeded just no longer served until balance is increased.
     
 ### /address
     Parameters
@@ -42,14 +58,6 @@ This project is for a server that will store and return data for a certain amoun
     Returns
         address - a new, unused Bitcoin address
 
-### /nonce
-    Parameters
-        address - account requesting a nonce
-        
-    Returns
-        nonce - random 32-byte string
-        
-Note: nonce is stored until used or next nonce generated for address
 
 ### /balance
     Parameters

--- a/causeway/default_settings.py
+++ b/causeway/default_settings.py
@@ -1,0 +1,5 @@
+'''Configuration file - copy to settings.py and fill in your own settings.'''
+
+DATA_DIR = '/home/twenty/storage'
+
+SERVER_PORT = 5000

--- a/causeway/default_settings.py
+++ b/causeway/default_settings.py
@@ -1,5 +1,8 @@
 '''Configuration file - copy to settings.py and fill in your own settings.'''
 
+SERVER_PORT = 5000
+ 
 DATA_DIR = '/home/twenty/storage'
 
-SERVER_PORT = 5000
+# Price in satoshis for 1MB storage and 50MB transfer
+PRICE = 1000

--- a/causeway/fileclient.py
+++ b/causeway/fileclient.py
@@ -1,0 +1,59 @@
+import sys
+import json
+import os
+
+# import from the 21 Developer Library
+from two1.commands.config import Config
+from two1.lib.wallet import Wallet
+from two1.lib.bitrequests import BitTransferRequests
+
+# set up bitrequest client for BitTransfer requests
+wallet = Wallet()
+username = Config().username
+requests = BitTransferRequests(wallet, username)
+
+# server address
+def buy_file(server_url = 'http://localhost:5000/'):
+
+    # get the file listing from the server
+    response = requests.get(url=server_url+'files')
+    file_list = json.loads(response.text)
+
+    # print the file list to the console
+    for file in range(len(file_list)):
+        print("{}. {}\t{}".format(file+1, file_list[str(file+1)][0], file_list[str(file+1)][1]))
+
+    try:
+        # prompt the user to input the index number of the file to be purchased
+        sel = input("Please enter the index of the file that you would like to purchase:")
+
+        # check if the input index is valid key in file_list dict
+        if sel in file_list:
+            print('You selected {} in our database'.format(file_list[sel][0]))
+
+            #create a 402 request with the server payout address
+            sel_url = server_url+'buy?selection={0}&payout_address={1}'
+            answer = requests.get(url=sel_url.format(int(sel), wallet.get_payout_address()), stream=True)
+            if answer.status_code != 200:
+                print("Could not make an offchain payment. Please check that you have sufficient balance.")
+            else:
+                # open a file with the same name as the file being purchased and stream the data into it.
+                filename = file_list[str(sel)][0]
+                with open(filename,'wb') as fd:
+                    for chunk in answer.iter_content(4096):
+                        fd.write(chunk)
+                fd.close()
+                print('Congratulations, you just purchased a file for bitcoin!')
+        else:
+            print("That is an invalid selection.")
+
+    except ValueError:
+        print("That is an invalid input. Only numerical inputs are accepted.")
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) > 1:
+        server_url = sys.argv[1]
+    else:
+        server_url = 'http://localhost:5000/'
+    buy_file(server_url)

--- a/causeway/fileserver.py
+++ b/causeway/fileserver.py
@@ -1,11 +1,10 @@
-import os
-import json
-import random
+import os, json, random, time, string
 from settings import *
 
 from flask import Flask
 from flask import request
 from flask import send_from_directory
+from flask import abort, url_for
 
 from two1.lib.wallet import Wallet
 from two1.lib.bitserv.flask import Payment
@@ -14,42 +13,90 @@ app = Flask(__name__)
 wallet = Wallet()
 payment = Payment(app, wallet)
 
+# start time
+start_time = time.time()
+stored = 0
+
 # get a list of the files in the directory
 file_list = os.listdir(DATA_DIR)
 
 # simple content model: dictionary of files w/ random prices
 files = {}
 for file_id in range(len(file_list)):
-    files[file_id+1] = file_list[file_id], random.randrange(3000, 6000)
+    file_name = file_list[file_id]
+    size = os.path.getsize(os.path.join(DATA_DIR, file_name))
+    price = size / 1024 / 50 * PRICE
+    if price < 1000:
+        price = 1000
+    files[file_id+1] = file_name, size, price
+
+
+@app.route('/status')
+def status():
+    '''Return general info about server instance. '''
+    uptime = str(int(time.time() - start_time))
+    st = os.statvfs(DATA_DIR)
+    free = st.f_bavail * st.f_frsize
+    return json.dumps({'uptime': uptime,
+                       'stored': str(stored),
+                       'free': str(free),
+                       'price': str(PRICE)
+                       }, indent=4
+                      )
 
 @app.route('/price')
 def price():
-    return
+    '''Return price for 1MB storage with bundled 50MB transfer.'''
+    return json.dumps({'price': PRICE}, indent=4)
 
+@app.route('/nonce')
+def nonce():
+    '''Return 32-byte nonce for generating non-reusable signatures..'''
+    n = ''.join(random.SystemRandom().choice(string.hexdigits) for _ in range(32))
+    return json.dumps({'nonce': n.lower()}, indent=4)
 
-# endpoint to look up files to buy
 @app.route('/files')
 def file_lookup():
+    '''List available files, size, and price.'''
     return json.dumps(files)
 
-# return the price of the selected file
+
 def get_price_from_request(request):
+    '''Return the price of the selected file.'''
     id = int(request.args.get('selection'))
     return files[id][1]
 
-# machine-payable endpoint that returns selected file if payment made
 @app.route('/buy')
 @payment.required(get_price_from_request)
 def buy_file():
-
+    '''Returns selected file if payment is made.'''
     # extract selection from client request
     sel = int(request.args.get('selection'))
 
     # check if selection is valid
     if(sel < 1 or sel > len(file_list)):
-        return 'Invalid selection.'
+         return abort(500)
     else:
         return send_from_directory(DATA_DIR, file_list[int(sel)-1])
+
+def has_no_empty_params(rule):
+    '''Testing rules to identify routes.'''
+    defaults = rule.defaults if rule.defaults is not None else ()
+    arguments = rule.arguments if rule.arguments is not None else ()
+    return len(defaults) >= len(arguments)
+
+@app.route('/help')
+def help():
+    '''Returns list of defined routes.'''
+    links = []
+    for rule in app.url_map.iter_rules():
+        # Filter out rules we can't navigate to in a browser
+        # and rules that require parameters
+        if "GET" in rule.methods and has_no_empty_params(rule):
+            url = url_for(rule.endpoint, **(rule.defaults or {}))
+            links.append(url)
+
+    return json.dumps(links, indent=4)
 
 if __name__ == '__main__':
     # app.debug = True

--- a/causeway/fileserver.py
+++ b/causeway/fileserver.py
@@ -1,0 +1,56 @@
+import os
+import json
+import random
+from settings import *
+
+from flask import Flask
+from flask import request
+from flask import send_from_directory
+
+from two1.lib.wallet import Wallet
+from two1.lib.bitserv.flask import Payment
+
+app = Flask(__name__)
+wallet = Wallet()
+payment = Payment(app, wallet)
+
+# get a list of the files in the directory
+file_list = os.listdir(DATA_DIR)
+
+# simple content model: dictionary of files w/ random prices
+files = {}
+for file_id in range(len(file_list)):
+    files[file_id+1] = file_list[file_id], random.randrange(3000, 6000)
+
+@app.route('/price')
+def price():
+    return
+
+
+# endpoint to look up files to buy
+@app.route('/files')
+def file_lookup():
+    return json.dumps(files)
+
+# return the price of the selected file
+def get_price_from_request(request):
+    id = int(request.args.get('selection'))
+    return files[id][1]
+
+# machine-payable endpoint that returns selected file if payment made
+@app.route('/buy')
+@payment.required(get_price_from_request)
+def buy_file():
+
+    # extract selection from client request
+    sel = int(request.args.get('selection'))
+
+    # check if selection is valid
+    if(sel < 1 or sel > len(file_list)):
+        return 'Invalid selection.'
+    else:
+        return send_from_directory(DATA_DIR, file_list[int(sel)-1])
+
+if __name__ == '__main__':
+    # app.debug = True
+    app.run(host='0.0.0.0', port=SERVER_PORT)


### PR DESCRIPTION
This is based on the fileserver.py example and will now report on some basic stats like disk space, uptime, and pricing for the server instance. Also included a /help endpoint which should list all of the available end points. The file purchase stuff is still in there and no additional machine-payable endpoints have been added, yet.
